### PR TITLE
Add support for onRangeChange when view changes

### DIFF
--- a/src/Calendar.js
+++ b/src/Calendar.js
@@ -688,11 +688,12 @@ class Calendar extends React.Component {
     );
   }
 
-  handleRangeChange = (date) => {
+  handleRangeChange = (date, nextView) => {
     let { onRangeChange } = this.props
+    let View = nextView ? VIEWS[nextView] : this.getView();
     if(onRangeChange) {
-      if(this.getView().range) {
-        onRangeChange(this.getView().range(date, {}))
+      if(View.range) {
+        onRangeChange(View.range(date, {}))
       }
       else {
         warning(true, 'onRangeChange prop not supported for this view')
@@ -717,7 +718,7 @@ class Calendar extends React.Component {
   handleViewChange = (view) => {
     if (view !== this.props.view && isValidView(view, this.props))
       this.props.onView(view)
-      this.handleRangeChange(this.props.date)
+      this.handleRangeChange(this.props.date, view)
   };
 
   handleSelectEvent = (...args) => {


### PR DESCRIPTION
I noticed that the when you changed the view `handleRangeChange` was receiving and using the previous view because `getView()` had a stale prop. This PR fixes that.

I wasn't sure if PRing on this fork was best, but seemed reasonable. I will make a comment in the already approved PR on the original intljusticemission repo that this should be reviewed.

Please let me know if there is anything else I should include with this as it is a feature that I need in my current project and would be happy to fiddle some more. Thanks @jhockett and @jquense!

Referencing [#641](https://github.com/intljusticemission/react-big-calendar/pull/641)